### PR TITLE
ARCH-919 - Make sure the space value is parsed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Update appsettings.json with Prod Values
-        uses: im-open/add-or-update-json-properties@v1.0.0
+        uses: im-open/add-or-update-json-properties@v1.0.1
         with:
           path-to-json-file: './src/MyApp/appsettings.json'
           properties-to-update-or-add: |

--- a/action.yml
+++ b/action.yml
@@ -6,13 +6,13 @@ inputs:
   path-to-json-file:
     description: 'The path and name of the json file to update'
     required: true
-  space:
-    description: 'The number of space characters to use as whitespace for indentation when the json file is saved.  Defaults to 2.'
-    required: false
-    default: 2
   properties-to-update-or-add:
     description: 'A json-parseable list of key value pairs to update the json with.  [{ "Logging.Level.Default": "Trace"}]'
     required: false
+  space:
+    description: 'The number of space characters to use as whitespace for indentation when the json file is saved.  Defaults to 2.'
+    required: false
+    default: '2'
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -997,7 +997,8 @@ var get = require_lodash2();
 function saveTheFile(jsonFile, fileContents) {
   core.info(`Saving changes to ${jsonFile}...`);
   const space = core.getInput('space');
-  const jsonData = JSON.stringify(fileContents, null, space);
+  const indentSpace = space && space.length > 0 ? parseInt(space) : 2;
+  const jsonData = JSON.stringify(fileContents, null, indentSpace);
   fs.writeFileSync(jsonFile, jsonData, 'utf8');
   core.info(`Finished Saving ${jsonFile}`);
 }

--- a/main.js
+++ b/main.js
@@ -6,7 +6,8 @@ const get = require('lodash.get');
 function saveTheFile(jsonFile, fileContents) {
   core.info(`Saving changes to ${jsonFile}...`);
   const space = core.getInput('space');
-  const jsonData = JSON.stringify(fileContents, null, space);
+  const indentSpace = space && space.length > 0 ? parseInt(space) : 2;
+  const jsonData = JSON.stringify(fileContents, null, indentSpace);
   fs.writeFileSync(jsonFile, jsonData, 'utf8');
   core.info(`Finished Saving ${jsonFile}`);
 }


### PR DESCRIPTION
When a number is passed as a string, it just uses that value as the character to use when spacing instead of the number of spaces to use which makes a mess of the json file.